### PR TITLE
fix(dev): Add jemalloc package to local docker image

### DIFF
--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -23,6 +23,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     htop \
     iputils-ping \
     jq \
+    libjemalloc-dev \
     less \
     sysstat \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
**Description**

The jemalloc package is missing, so Dgraph fails to build. This PR adds it.
